### PR TITLE
Reduce specificity for RxSwift podspec dependency

### DIFF
--- a/RxAutomaton.podspec
+++ b/RxAutomaton.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/inamiy/RxAutomaton.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/**/*.swift"
 
-  s.dependency "RxSwift", "~> 3.0.0"
+  s.dependency "RxSwift", "~> 3.0"
 end

--- a/Sources/Automaton.swift
+++ b/Sources/Automaton.swift
@@ -175,7 +175,7 @@ extension ObservableType {
             case let .error(error):
                 let error = "Binding error to variable: \(error)"
                 #if DEBUG
-                    rxFatalError(error)
+                    fatalError(error)
                 #else
                     print(error)
                 #endif


### PR DESCRIPTION
`s.dependency "RxSwift", "~> 3.0.0"` is too specific, causing conflicts with packages using newer
versions of RxSwift in the 3.x series.  Use `~> 3.0` instead.

I have updated Carthage dependencies locally, built, and run tests (all passed), but did not include the Carthage updates on this PR.  Those are easy to add, if useful.  Tested with Carthage versions:

```
github "Quick/Nimble" "v6.1.0"
github "Quick/Quick" "v1.1.0"
github "ReactiveX/RxSwift" "3.4.0"
github "mrackwitz/xcconfigs" "3.0"
github "shu223/Pulsator" "0.3.0"
```
