### PR TITLE
Fix double subscription bug

### DIFF
--- a/Sources/Automaton.swift
+++ b/Sources/Automaton.swift
@@ -78,7 +78,7 @@ public final class Automaton<State, Input>
                     .map { input, fromState in
                         return (input, fromState, mapping(fromState, input)?.1)
                     }
-                    .share(replay: 1)
+                    .share(replay: 1, scope: .forever)
 
                 let successSignal = mappingSignal
                     .filterMap { input, fromState, effect in
@@ -110,7 +110,7 @@ public final class Automaton<State, Input>
                     return .just(.failure(input, fromState))
                 }
             }
-            .share(replay: 1)
+            .share(replay: 1, scope: .forever)
 
         replySignal
             .flatMap(.merge) { reply -> Observable<State> in


### PR DESCRIPTION
Hello, my team recently start a transition to RxSwfit 4.x, as far as I can see, RxAutomaton does not have rxswift 4 branch and HEAD dependency is `~> 4.0.0`. After manual transition(plain dependency bump) we have observed strange behavior: `RxAutomaton` subscribes to each cold edge twice.

The bug was caused by updated `.share` operator, which now have two parameters(replay elements count and strategy) with strange default values: by default new share behavior differs from the old one. 

My PR contains three commits: 
- dependency bump
- test case, that exposes a bug(https://github.com/inamiy/RxAutomaton/commit/5b2431af90b71593d24b163a164a340d598b5c83)
- fix (https://github.com/inamiy/RxAutomaton/commit/44703bf93a8950f81db3ec3c15a5e689b0836937)

So far, this is the only critical issue, caused by the transition to RxSwift 4.x, maybe we should perform needed tests/warning fixes and bump dependency version?